### PR TITLE
feat: ロック画面 (lock.qml) の実装

### DIFF
--- a/LockContext.qml
+++ b/LockContext.qml
@@ -27,6 +27,12 @@ Scope {
                 this.respond(root.currentText)
             }
         }
+        onError: (err) => {
+            console.error("PAM error:", err)
+            root.currentText = ""
+            root.showFailure = true
+            root.unlockInProgress = false
+        }
         onCompleted: (result) => {
             if (result === PamResult.Success) {
                 root.unlocked()

--- a/LockContext.qml
+++ b/LockContext.qml
@@ -22,8 +22,10 @@ Scope {
         id: pam
         configDirectory: "pam"
         config: "quickshell"
-        onPamMessage: (message) => {
-            if (message.responseRequired) message.respond(root.currentText)
+        onPamMessage: {
+            if (this.responseRequired) {
+                this.respond(root.currentText)
+            }
         }
         onCompleted: (result) => {
             if (result === PamResult.Success) {

--- a/LockContext.qml
+++ b/LockContext.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import Quickshell
+import Quickshell.Services.Pam
+
+Scope {
+    id: root
+
+    signal unlocked()
+
+    property string currentText: ""
+    property bool unlockInProgress: false
+    property bool showFailure: false
+    onCurrentTextChanged: showFailure = false
+
+    function tryUnlock() {
+        if (root.currentText === "") return
+        root.unlockInProgress = true
+        pam.start()
+    }
+
+    PamContext {
+        id: pam
+        configDirectory: "pam"
+        config: "quickshell"
+        onPamMessage: (message) => {
+            if (message.responseRequired) message.respond(root.currentText)
+        }
+        onCompleted: (result) => {
+            if (result === PamResult.Success) {
+                root.unlocked()
+            } else {
+                root.currentText = ""
+                root.showFailure = true
+            }
+            root.unlockInProgress = false
+        }
+    }
+}

--- a/LockSurface.qml
+++ b/LockSurface.qml
@@ -24,78 +24,84 @@ Rectangle {
         fillMode: Image.PreserveAspectCrop
     }
 
-    Column {
-        id: clockArea
+    Rectangle {
+        id: glassPanel
         anchors.centerIn: parent
-        spacing: 8
+        width: 380
+        height: glassContent.height + 64
+        radius: 16
+        color: Qt.rgba(0.118, 0.118, 0.180, 0.75)
+        border.width: 1
+        border.color: root.ctpOverlay0
 
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            font.pixelSize: 96
-            color: root.ctpText
-            font.family: root.fontName
-            text: Qt.formatDateTime(new Date(), "HH:mm")
-            Timer { running: true; repeat: true; interval: 1000; onTriggered: parent.text = Qt.formatDateTime(new Date(), "HH:mm") }
-        }
+        Column {
+            id: glassContent
+            anchors.centerIn: parent
+            spacing: 0
 
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            font.pixelSize: 20
-            color: root.ctpSubtext1
-            font.family: root.fontName
-            text: Qt.formatDateTime(new Date(), "yyyy/MM/dd")
-            Timer { running: true; repeat: true; interval: 1000; onTriggered: parent.text = Qt.formatDateTime(new Date(), "yyyy/MM/dd") }
-        }
-    }
-
-    ColumnLayout {
-        anchors.top: clockArea.bottom
-        anchors.topMargin: 40
-        anchors.horizontalCenter: parent.horizontalCenter
-        spacing: 12
-
-        Rectangle {
-            Layout.alignment: Qt.AlignHCenter
-            width: 320
-            height: 44
-            radius: 22
-            color: root.ctpSurface0
-            border.width: 1
-            border.color: passwordInput.activeFocus ? root.ctpLavender : root.ctpOverlay0
-
-            TextInput {
-                id: passwordInput
-                anchors.fill: parent
-                anchors.leftMargin: 16
-                anchors.rightMargin: 16
-                verticalAlignment: TextInput.AlignVCenter
-                echoMode: TextInput.Password
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                font.pixelSize: 96
                 color: root.ctpText
                 font.family: root.fontName
-                font.pixelSize: 16
-                enabled: !root.context.unlockInProgress
-                focus: true
-                inputMethodHints: Qt.ImhSensitiveData
-                onTextChanged: root.context.currentText = text
-                onAccepted: root.context.tryUnlock()
+                text: Qt.formatDateTime(new Date(), "HH:mm")
+                Timer { running: true; repeat: true; interval: 1000; onTriggered: parent.text = Qt.formatDateTime(new Date(), "HH:mm") }
+            }
 
-                Connections {
-                    target: root.context
-                    function onCurrentTextChanged() {
-                        if (passwordInput.text !== root.context.currentText)
-                            passwordInput.text = root.context.currentText
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                bottomPadding: 32
+                font.pixelSize: 20
+                color: root.ctpSubtext1
+                font.family: root.fontName
+                text: Qt.formatDateTime(new Date(), "yyyy/MM/dd")
+                Timer { running: true; repeat: true; interval: 1000; onTriggered: parent.text = Qt.formatDateTime(new Date(), "yyyy/MM/dd") }
+            }
+
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: 320
+                height: 44
+                radius: 22
+                color: root.ctpSurface0
+                border.width: 1
+                border.color: passwordInput.activeFocus ? root.ctpLavender : root.ctpOverlay0
+
+                TextInput {
+                    id: passwordInput
+                    anchors.fill: parent
+                    anchors.leftMargin: 16
+                    anchors.rightMargin: 16
+                    verticalAlignment: TextInput.AlignVCenter
+                    echoMode: TextInput.Password
+                    color: root.ctpText
+                    font.family: root.fontName
+                    font.pixelSize: 16
+                    enabled: !root.context.unlockInProgress
+                    focus: true
+                    inputMethodHints: Qt.ImhSensitiveData
+                    onTextChanged: root.context.currentText = text
+                    onAccepted: root.context.tryUnlock()
+
+                    Connections {
+                        target: root.context
+                        function onCurrentTextChanged() {
+                            if (passwordInput.text !== root.context.currentText)
+                                passwordInput.text = root.context.currentText
+                        }
                     }
                 }
             }
-        }
 
-        Text {
-            Layout.alignment: Qt.AlignHCenter
-            visible: root.context.showFailure
-            text: "パスワードが正しくありません"
-            color: root.ctpRed
-            font.family: root.fontName
-            font.pixelSize: 14
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                topPadding: 8
+                opacity: root.context.showFailure ? 1.0 : 0.0
+                text: "\u30d1\u30b9\u30ef\u30fc\u30c9\u304c\u6b63\u3057\u304f\u3042\u308a\u307e\u305b\u3093"
+                color: root.ctpRed
+                font.family: root.fontName
+                font.pixelSize: 14
+            }
         }
     }
 }

--- a/LockSurface.qml
+++ b/LockSurface.qml
@@ -14,13 +14,14 @@ Rectangle {
     readonly property color ctpSubtext1: "#bac2de"
     readonly property color ctpLavender: "#b4befe"
     readonly property color ctpRed: "#f38ba8"
+    required property string wallpaperSource
     readonly property string fontName: "NotoSans Nerd Font"
 
     color: ctpBase
 
     Image {
         anchors.fill: parent
-        source: "/home/riou/.config/background/catppuccin_ekg_1.png"
+        source: root.wallpaperSource
         fillMode: Image.PreserveAspectCrop
     }
 

--- a/LockSurface.qml
+++ b/LockSurface.qml
@@ -18,13 +18,19 @@ Rectangle {
 
     color: ctpBase
 
+    Image {
+        anchors.fill: parent
+        source: "/home/riou/.config/background/catppuccin_ekg_1.png"
+        fillMode: Image.PreserveAspectCrop
+    }
+
     Column {
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
-        anchors.topMargin: parent.height * 0.2
+        id: clockArea
+        anchors.centerIn: parent
         spacing: 8
 
         Text {
+            anchors.horizontalCenter: parent.horizontalCenter
             font.pixelSize: 96
             color: root.ctpText
             font.family: root.fontName
@@ -33,6 +39,7 @@ Rectangle {
         }
 
         Text {
+            anchors.horizontalCenter: parent.horizontalCenter
             font.pixelSize: 20
             color: root.ctpSubtext1
             font.family: root.fontName
@@ -42,8 +49,9 @@ Rectangle {
     }
 
     ColumnLayout {
-        anchors.centerIn: parent
-        anchors.verticalCenterOffset: parent.height * 0.1
+        anchors.top: clockArea.bottom
+        anchors.topMargin: 40
+        anchors.horizontalCenter: parent.horizontalCenter
         spacing: 12
 
         Rectangle {

--- a/LockSurface.qml
+++ b/LockSurface.qml
@@ -1,0 +1,93 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell.Wayland
+
+Rectangle {
+    id: root
+
+    required property LockContext context
+
+    readonly property color ctpBase: "#1e1e2e"
+    readonly property color ctpSurface0: "#313244"
+    readonly property color ctpOverlay0: "#6c7086"
+    readonly property color ctpText: "#cdd6f4"
+    readonly property color ctpSubtext1: "#bac2de"
+    readonly property color ctpLavender: "#b4befe"
+    readonly property color ctpRed: "#f38ba8"
+    readonly property string fontName: "NotoSans Nerd Font"
+
+    color: ctpBase
+
+    Column {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: parent.height * 0.2
+        spacing: 8
+
+        Text {
+            font.pixelSize: 96
+            color: root.ctpText
+            font.family: root.fontName
+            text: Qt.formatDateTime(new Date(), "HH:mm")
+            Timer { running: true; repeat: true; interval: 1000; onTriggered: parent.text = Qt.formatDateTime(new Date(), "HH:mm") }
+        }
+
+        Text {
+            font.pixelSize: 20
+            color: root.ctpSubtext1
+            font.family: root.fontName
+            text: Qt.formatDateTime(new Date(), "yyyy/MM/dd")
+            Timer { running: true; repeat: true; interval: 1000; onTriggered: parent.text = Qt.formatDateTime(new Date(), "yyyy/MM/dd") }
+        }
+    }
+
+    ColumnLayout {
+        anchors.centerIn: parent
+        anchors.verticalCenterOffset: parent.height * 0.1
+        spacing: 12
+
+        Rectangle {
+            Layout.alignment: Qt.AlignHCenter
+            width: 320
+            height: 44
+            radius: 22
+            color: root.ctpSurface0
+            border.width: 1
+            border.color: passwordInput.activeFocus ? root.ctpLavender : root.ctpOverlay0
+
+            TextInput {
+                id: passwordInput
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                verticalAlignment: TextInput.AlignVCenter
+                echoMode: TextInput.Password
+                color: root.ctpText
+                font.family: root.fontName
+                font.pixelSize: 16
+                enabled: !root.context.unlockInProgress
+                focus: true
+                inputMethodHints: Qt.ImhSensitiveData
+                onTextChanged: root.context.currentText = text
+                onAccepted: root.context.tryUnlock()
+
+                Connections {
+                    target: root.context
+                    function onCurrentTextChanged() {
+                        if (passwordInput.text !== root.context.currentText)
+                            passwordInput.text = root.context.currentText
+                    }
+                }
+            }
+        }
+
+        Text {
+            Layout.alignment: Qt.AlignHCenter
+            visible: root.context.showFailure
+            text: "パスワードが正しくありません"
+            color: root.ctpRed
+            font.family: root.fontName
+            font.pixelSize: 14
+        }
+    }
+}

--- a/lock.qml
+++ b/lock.qml
@@ -1,0 +1,24 @@
+import Quickshell
+import Quickshell.Wayland
+
+ShellRoot {
+    LockContext {
+        id: lockContext
+        onUnlocked: {
+            lock.locked = false
+            Qt.quit()
+        }
+    }
+
+    WlSessionLock {
+        id: lock
+        locked: true
+
+        WlSessionLockSurface {
+            LockSurface {
+                anchors.fill: parent
+                context: lockContext
+            }
+        }
+    }
+}

--- a/lock.qml
+++ b/lock.qml
@@ -16,6 +16,7 @@ ShellRoot {
 
         WlSessionLockSurface {
             LockSurface {
+                wallpaperSource: "/home/riou/.config/background/catppuccin_ekg_1.png"
                 anchors.fill: parent
                 context: lockContext
             }

--- a/pam/quickshell
+++ b/pam/quickshell
@@ -1,0 +1,1 @@
+auth include login

--- a/pam/quickshell
+++ b/pam/quickshell
@@ -1,1 +1,1 @@
-auth include login
+auth include system-auth

--- a/pam/quickshell
+++ b/pam/quickshell
@@ -1,1 +1,1 @@
-auth include system-auth
+auth required pam_unix.so


### PR DESCRIPTION
## 関連 issue

Closes #2

## 概要

Quickshell の `WlSessionLock` + `Quickshell.Services.Pam` を使用した Wayland ロック画面を実装した。

## 実装ファイル

| ファイル | 説明 |
|---|---|
| `lock.qml` | エントリポイント。起動直後にセッションをロックし、認証成功後に解除・終了 |
| `LockContext.qml` | PAM 認証ロジック。全スクリーン共有の状態管理 |
| `LockSurface.qml` | 各スクリーンに表示される UI |
| `pam/quickshell` | PAM 設定 (`auth required pam_unix.so`) |

## 変更内容

### 実装 (17385f5)
- `WlSessionLock` によるセッションロック
- `PamContext` による PAM 認証（パスワード入力 → アンロック）
- Catppuccin Mocha テーマの UI（時計・日付・パスワード入力欄）

### バグ修正 (9060e14, adf4553)
- `onPamMessage` ハンドラの構文誤り修正  
  arrow function `(message) => {}` では `message` が `undefined` になりパスワードが PAM に渡されなかったため、`this` 参照に変更
- PAM 設定を `auth include login` → `auth required pam_unix.so` に変更  
  `login` / `system-auth` 経由では `pam_faillock.so` が作動し、ロック画面の失敗がアカウントロックアウトカウントに加算される問題があった
- `PamContext.onError` ハンドラを追加（PAM ライブラリ自体の異常を検知）

### デザイン (9fec1f6, d292672)
- 背景に壁紙画像 (`catppuccin_ekg_1.png`) を追加
- 時計・日付・パスワード入力を半透明パネル (`ctpBase @ 75%`) にまとめて画面中央に配置  
  `bar.qml` の各カラムと統一したスタイル（`radius: 16`、`ctpOverlay0` ボーダー）

## 起動方法

```sh
qs -p ~/.config/quickshell/lock.qml
```