### PR TITLE
refactor: add root. prefix and pragma ComponentBehavior: Bound

### DIFF
--- a/bar.qml
+++ b/bar.qml
@@ -7,6 +7,7 @@ import Quickshell.Widgets
 import Quickshell.I3
 import Quickshell.Services.Mpris
 import Quickshell.Services.SystemTray
+import Quickshell.DBusMenu
 
 ShellRoot {
     Variants {
@@ -61,34 +62,34 @@ ShellRoot {
                 interval: 1000
                 running: true
                 repeat: true
-                onTriggered: updateTime()
+                onTriggered: root.updateTime()
             }
             Item {
                 id: content
                 anchors.fill: parent
-                anchors.margins: barPadding
+                anchors.margins: root.barPadding
 
                 // Left column: Workspaces
                 Rectangle {
                     id: workspaceCol
                     anchors.left: parent.left
                     anchors.verticalCenter: parent.verticalCenter
-                    color: ctpSurface0
-                    radius: colRadius
+                    color: root.ctpSurface0
+                    radius: root.colRadius
                     border.width: 1
-                    border.color: ctpOverlay0
+                    border.color: root.ctpOverlay0
 
-                    implicitHeight: Math.max(iconSize, workspaceRow.implicitHeight) + (colPaddingY * 2)
-                    implicitWidth: workspaceRow.implicitWidth + (colPaddingX * 2)
+                    implicitHeight: Math.max(root.iconSize, workspaceRow.implicitHeight) + (root.colPaddingY * 2)
+                    implicitWidth: workspaceRow.implicitWidth + (root.colPaddingX * 2)
 
                     RowLayout {
                         id: workspaceRow
                         anchors.fill: parent
-                        anchors.leftMargin: colPaddingX
-                        anchors.rightMargin: colPaddingX
-                        anchors.topMargin: colPaddingY
-                        anchors.bottomMargin: colPaddingY
-                        spacing: colSpacing
+                        anchors.leftMargin: root.colPaddingX
+                        anchors.rightMargin: root.colPaddingX
+                        anchors.topMargin: root.colPaddingY
+                        anchors.bottomMargin: root.colPaddingY
+                        spacing: root.colSpacing
 
                         Repeater {
                             model: I3.workspaces
@@ -98,20 +99,20 @@ ShellRoot {
                                 required property I3Workspace modelData
 
                                 radius: 4
-                                color: modelData.focused ? ctpLavender : modelData.active ? ctpSurface1 : "transparent"
+                                color: modelData.focused ? root.ctpLavender : modelData.active ? root.ctpSurface1 : "transparent"
 
                                 border.width: modelData.urgent ? 1 : 0
-                                border.color: modelData.urgent ? ctpRed : "transparent"
+                                border.color: modelData.urgent ? root.ctpRed : "transparent"
 
                                 implicitHeight: 18
                                 implicitWidth: 22
 
                                 Text {
                                     anchors.centerIn: parent
-                                    text: modelData.name
-                                    color: modelData.focused ? ctpBase : ctpText
-                                    font.family: fontName
-                                    font.pixelSize: baseFontSize
+                                    text: wsItem.modelData.name
+                                    color: wsItem.modelData.focused ? root.ctpBase : root.ctpText
+                                    font.family: root.fontName
+                                    font.pixelSize: root.baseFontSize
                                 }
 
                                 MouseArea {
@@ -127,24 +128,24 @@ ShellRoot {
                 Rectangle {
                     id: trayCol
                     anchors.right: clockCol.left
-                    anchors.rightMargin: trayClockGap
+                    anchors.rightMargin: root.trayClockGap
                     anchors.verticalCenter: parent.verticalCenter
-                    color: ctpSurface0
-                    radius: colRadius
+                    color: root.ctpSurface0
+                    radius: root.colRadius
                     border.width: 1
-                    border.color: ctpOverlay0
+                    border.color: root.ctpOverlay0
 
-                    implicitHeight: Math.max(iconSize, trayRow.implicitHeight) + (colPaddingY * 2)
-                    implicitWidth: trayRow.implicitWidth + (colPaddingX * 2)
+                    implicitHeight: Math.max(root.iconSize, trayRow.implicitHeight) + (root.colPaddingY * 2)
+                    implicitWidth: trayRow.implicitWidth + (root.colPaddingX * 2)
 
                     RowLayout {
                         id: trayRow
                         anchors.fill: parent
-                        anchors.leftMargin: colPaddingX
-                        anchors.rightMargin: colPaddingX
-                        anchors.topMargin: colPaddingY
-                        anchors.bottomMargin: colPaddingY
-                        spacing: colSpacing
+                        anchors.leftMargin: root.colPaddingX
+                        anchors.rightMargin: root.colPaddingX
+                        anchors.topMargin: root.colPaddingY
+                        anchors.bottomMargin: root.colPaddingY
+                        spacing: root.colSpacing
 
                         Repeater {
                             model: SystemTray.items
@@ -153,12 +154,12 @@ ShellRoot {
                                 id: trayItemRoot
                                 required property SystemTrayItem modelData
 
-                                width: iconSize
-                                height: iconSize
+                                width: root.iconSize
+                                height: root.iconSize
 
                                 IconImage {
                                     anchors.centerIn: parent
-                                    implicitSize: iconSize
+                                    implicitSize: root.iconSize
                                     source: trayItemRoot.modelData.icon
                                 }
 
@@ -200,27 +201,27 @@ ShellRoot {
                     id: clockCol
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
-                    color: ctpSurface0
-                    radius: colRadius
+                    color: root.ctpSurface0
+                    radius: root.colRadius
                     border.width: 1
-                    border.color: ctpOverlay0
+                    border.color: root.ctpOverlay0
 
-                    implicitHeight: Math.max(iconSize, clockRow.implicitHeight) + (colPaddingY * 2)
-                    implicitWidth: clockRow.implicitWidth + (colPaddingX * 2)
+                    implicitHeight: Math.max(root.iconSize, clockRow.implicitHeight) + (root.colPaddingY * 2)
+                    implicitWidth: clockRow.implicitWidth + (root.colPaddingX * 2)
 
                     RowLayout {
                         id: clockRow
                         anchors.fill: parent
-                        anchors.leftMargin: colPaddingX
-                        anchors.rightMargin: colPaddingX
-                        anchors.topMargin: colPaddingY
-                        anchors.bottomMargin: colPaddingY
-                        spacing: colSpacing
+                        anchors.leftMargin: root.colPaddingX
+                        anchors.rightMargin: root.colPaddingX
+                        anchors.topMargin: root.colPaddingY
+                        anchors.bottomMargin: root.colPaddingY
+                        spacing: root.colSpacing
 
                         Text {
-                            color: ctpSubtext1
-                            font.family: fontName
-                            font.pixelSize: baseFontSize
+                            color: root.ctpSubtext1
+                            font.family: root.fontName
+                            font.pixelSize: root.baseFontSize
                             text: ` ${root.dateText} 󰇙  ${root.timeText}`
                         }
                     }
@@ -229,10 +230,10 @@ ShellRoot {
                 Rectangle {
                     id: mediaCol
                     anchors.centerIn: parent
-                    color: ctpSurface0
-                    radius: colRadius
+                    color: root.ctpSurface0
+                    radius: root.colRadius
                     border.width: 1
-                    border.color: ctpOverlay0
+                    border.color: root.ctpOverlay0
 
                     property var activePlayer: {
                         const players = Mpris.players.values;
@@ -249,45 +250,45 @@ ShellRoot {
 
                     readonly property string mediaStatusIcon: activePlayer ? (activePlayer.isPlaying ? "" : "") : ""
 
-                    readonly property int availableWidth: Math.max(0, parent.width - workspaceCol.width - trayCol.width - (colPaddingX * 2) - 24)
+                    readonly property int availableWidth: Math.max(0, parent.width - workspaceCol.width - trayCol.width - (root.colPaddingX * 2) - 24)
 
                     TextMetrics {
                         id: mediaTitleMetrics
                         text: mediaCol.mediaTitle
-                        font.family: fontName
-                        font.pixelSize: baseFontSize
+                        font.family: root.fontName
+                        font.pixelSize: root.baseFontSize
                     }
 
                     TextMetrics {
                         id: mediaStatusMetrics
                         text: mediaCol.mediaStatusIcon
-                        font.family: fontName
-                        font.pixelSize: baseFontSize
+                        font.family: root.fontName
+                        font.pixelSize: root.baseFontSize
                     }
 
-                    implicitHeight: Math.max(mediaTitleMetrics.height, mediaStatusMetrics.height, iconSize) + (colPaddingY * 2)
-                    width: Math.min(availableWidth, mediaStatusMetrics.width + colSpacing + mediaTitleMetrics.width + (colPaddingX * 2))
+                    implicitHeight: Math.max(mediaTitleMetrics.height, mediaStatusMetrics.height, root.iconSize) + (root.colPaddingY * 2)
+                    width: Math.min(availableWidth, mediaStatusMetrics.width + root.colSpacing + mediaTitleMetrics.width + (root.colPaddingX * 2))
 
                     RowLayout {
                         anchors.fill: parent
-                        anchors.leftMargin: colPaddingX
-                        anchors.rightMargin: colPaddingX
-                        anchors.topMargin: colPaddingY
-                        anchors.bottomMargin: colPaddingY
-                        spacing: colSpacing
+                        anchors.leftMargin: root.colPaddingX
+                        anchors.rightMargin: root.colPaddingX
+                        anchors.topMargin: root.colPaddingY
+                        anchors.bottomMargin: root.colPaddingY
+                        spacing: root.colSpacing
 
                         Text {
-                            color: ctpSubtext1
-                            font.family: fontName
-                            font.pixelSize: baseFontSize
+                            color: root.ctpSubtext1
+                            font.family: root.fontName
+                            font.pixelSize: root.baseFontSize
                             text: mediaCol.mediaStatusIcon
                         }
 
                         Text {
                             Layout.fillWidth: true
-                            color: ctpText
-                            font.family: fontName
-                            font.pixelSize: baseFontSize
+                            color: root.ctpText
+                            font.family: root.fontName
+                            font.pixelSize: root.baseFontSize
                             elide: Text.ElideRight
                             text: mediaCol.mediaTitle
                         }

--- a/notify.qml
+++ b/notify.qml
@@ -1,3 +1,4 @@
+pragma ComponentBehavior: Bound
 import Quickshell
 import QtQuick
 import QtQuick.Layouts
@@ -11,11 +12,15 @@ ShellRoot {
 
     readonly property int maxNotifications: 2
     readonly property int timeoutMs: 3000
-    readonly property int barPadding: 8
-    readonly property int cardRadius: 8
-    readonly property int cardPadding: 10
-    readonly property int cardSpacing: 8
-    readonly property int iconSize: 28
+
+    // Golden ratio based design (matching bar.qml)
+    readonly property real phi: 1.618
+    readonly property int baseFontSize: 14
+    readonly property int barPadding: Math.round(root.baseFontSize / root.phi)
+    readonly property int cardPadding: Math.round(root.baseFontSize / root.phi)
+    readonly property int cardSpacing: Math.round(root.baseFontSize / (root.phi * root.phi))
+    readonly property int cardRadius: Math.round(root.baseFontSize / (root.phi * root.phi)) + 3
+    readonly property int iconSize: Math.round(root.baseFontSize * root.phi)
 
     // Catppuccin Mocha palette
     readonly property color ctpBase: "#1e1e2e"
@@ -25,6 +30,9 @@ ShellRoot {
     readonly property color ctpSubtext1: "#bac2de"
     readonly property color ctpBlue: "#89b4fa"
     readonly property color ctpRed: "#f38ba8"
+
+    // Font settings (matching bar.qml)
+    readonly property string fontFamily: "Noto Sans CJK JP"
 
     property var notificationTimes: ({})
     property int ticker: 0
@@ -86,7 +94,7 @@ ShellRoot {
                 right: true
             }
 
-            screen: modelData
+            screen: window.modelData
             color: "transparent"
             aboveWindows: true
             exclusiveZone: 0
@@ -98,7 +106,7 @@ ShellRoot {
                 id: popup
                 anchor.window: window
                 anchor.rect.x: (window.width - width) / 2
-                anchor.rect.y: barPadding
+                anchor.rect.y: root.barPadding
                 implicitWidth: Math.min(window.width, 480)
                 implicitHeight: stack.implicitHeight
                 color: "transparent"
@@ -107,7 +115,7 @@ ShellRoot {
                 ColumnLayout {
                     id: stack
                     width: parent.width
-                    spacing: cardSpacing
+                    spacing: root.cardSpacing
 
                     Repeater {
                         model: root.latestNotifications()
@@ -122,47 +130,47 @@ ShellRoot {
                                 return Math.max(0, 1 - (elapsed / root.timeoutMs));
                             }
 
-                            radius: cardRadius
-                            color: ctpSurface0
+                            radius: root.cardRadius
+                            color: root.ctpSurface0
                             border.width: 1
-                            border.color: modelData.urgency === NotificationUrgency.Critical ? ctpRed : ctpBlue
+                            border.color: modelData.urgency === NotificationUrgency.Critical ? root.ctpRed : root.ctpBlue
 
                             Layout.fillWidth: true
-                            implicitHeight: Math.max(iconSize, summaryText.implicitHeight + bodyText.implicitHeight + 6) + (cardPadding * 2)
+                            implicitHeight: Math.max(root.iconSize, summaryText.implicitHeight + bodyText.implicitHeight + 6) + (root.cardPadding * 2)
 
                             MouseArea {
                                 anchors.fill: parent
-                                onClicked: modelData.dismiss()
+                                onClicked: card.modelData.dismiss()
                             }
 
                             RowLayout {
                                 id: cardRow
                                 anchors.fill: parent
-                                anchors.margins: cardPadding
+                                anchors.margins: root.cardPadding
                                 spacing: 10
 
                                 Item {
-                                    width: iconSize
-                                    height: iconSize
+                                    implicitWidth: root.iconSize
+                                    implicitHeight: root.iconSize
                                     visible: iconImage.visible || appIcon.visible
 
                                     Image {
                                         id: iconImage
                                         anchors.centerIn: parent
-                                        width: iconSize
-                                        height: iconSize
-                                        source: modelData.image
+                                        width: root.iconSize
+                                        height: root.iconSize
+                                        source: card.modelData.image
                                         fillMode: Image.PreserveAspectFit
                                         smooth: true
-                                        visible: modelData.image && modelData.image !== ""
+                                        visible: card.modelData.image && card.modelData.image !== ""
                                     }
 
                                     IconImage {
                                         id: appIcon
                                         anchors.centerIn: parent
-                                        implicitSize: iconSize
-                                        source: modelData.appIcon
-                                        visible: !iconImage.visible && modelData.appIcon && modelData.appIcon !== ""
+                                        implicitSize: root.iconSize
+                                        source: card.modelData.appIcon
+                                        visible: !iconImage.visible && card.modelData.appIcon && card.modelData.appIcon !== ""
                                     }
                                 }
 
@@ -172,8 +180,8 @@ ShellRoot {
 
                                     Text {
                                         id: summaryText
-                                        text: modelData.summary || modelData.appName
-                                        color: ctpText
+                                        text: card.modelData.summary || card.modelData.appName
+                                        color: root.ctpText
                                         font.pixelSize: 15
                                         elide: Text.ElideRight
                                         wrapMode: Text.NoWrap
@@ -182,8 +190,8 @@ ShellRoot {
 
                                     Text {
                                         id: bodyText
-                                        text: modelData.body
-                                        color: ctpSubtext1
+                                        text: card.modelData.body
+                                        color: root.ctpSubtext1
                                         font.pixelSize: 13
                                         elide: Text.ElideRight
                                         wrapMode: Text.WordWrap
@@ -191,8 +199,8 @@ ShellRoot {
                                     }
 
                                     Rectangle {
-                                        height: 2
-                                        color: ctpOverlay0
+                                        implicitHeight: 2
+                                        color: root.ctpOverlay0
                                         Layout.fillWidth: true
 
                                         Rectangle {
@@ -200,7 +208,7 @@ ShellRoot {
                                             anchors.top: parent.top
                                             anchors.bottom: parent.bottom
                                             width: parent.width * card.progress
-                                            color: modelData.urgency === NotificationUrgency.Critical ? ctpRed : ctpBlue
+                                            color: card.modelData.urgency === NotificationUrgency.Critical ? root.ctpRed : root.ctpBlue
                                         }
                                     }
                                 }

--- a/notify.qml
+++ b/notify.qml
@@ -182,6 +182,7 @@ ShellRoot {
                                         id: summaryText
                                         text: card.modelData.summary || card.modelData.appName
                                         color: root.ctpText
+                                        font.family: root.fontFamily
                                         font.pixelSize: 15
                                         elide: Text.ElideRight
                                         wrapMode: Text.NoWrap
@@ -192,6 +193,7 @@ ShellRoot {
                                         id: bodyText
                                         text: card.modelData.body
                                         color: root.ctpSubtext1
+                                        font.family: root.fontFamily
                                         font.pixelSize: 13
                                         elide: Text.ElideRight
                                         wrapMode: Text.WordWrap


### PR DESCRIPTION
## 概要

`pragma ComponentBehavior: Bound` に準拠したプロパティ参照の修正と、`notify.qml` のデザイン定数を `bar.qml` と統一する。

## 変更内容

### `bar.qml`
- 子コンポーネント内のすべてのプロパティ参照に `root.` プレフィックスを追加
  - パレット定数、レイアウト定数、メソッド呼び出しすべてに適用
  - `modelData.name` → `wsItem.modelData.name` など `required property` スコープも明示

### `notify.qml`
- `pragma ComponentBehavior: Bound` を追加
- デザイン定数をゴールデンレシオベースに変更（`bar.qml` と統一）
  - `barPadding` / `cardPadding` / `cardSpacing` / `cardRadius` / `iconSize`
- `fontFamily` プロパティを追加（`Noto Sans CJK JP`）
- スコープ付きプロパティ参照を修正
  - `screen: modelData` → `screen: window.modelData`
  - `onClicked: modelData.dismiss()` → `onClicked: card.modelData.dismiss()`
  - 全プロパティ参照に `root.` プレフィックスを追加